### PR TITLE
Dockerfile: Bump openSUSE to 15.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/leap:42.3
+FROM opensuse/leap:15.6
 
 RUN zypper -n --gpg-auto-import-keys ref && \
     zypper -n --gpg-auto-import-keys up && \


### PR DESCRIPTION
openSUSE 42.3 is from 2019 and is end of life for many years: https://en.opensuse.org/Lifetime#Discontinued_distributions